### PR TITLE
redeploy and cancel autodeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ after_success:
   - Rscript -e 'covr::codecov()'
 
 # Added for shinyapps.io deployment
-dist: xenial
-sudo: false
-latex: false
-
-deploy:
-  provider: script
-  script: 
-    - R -f deploy.R
-  on:
-    branch: master
+# dist: xenial
+# sudo: false
+# latex: false
+# 
+# deploy:
+#   provider: script
+#   script: 
+#     - R -f deploy.R
+#   on:
+#     branch: master

--- a/rsconnect/shinyapps.io/julianstanley/gfpopgui.dcf
+++ b/rsconnect/shinyapps.io/julianstanley/gfpopgui.dcf
@@ -5,9 +5,9 @@ account: julianstanley
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 2366586
-bundleId: 3202696
+bundleId: 3204435
 url: https://julianstanley.shinyapps.io/gfpopgui/
-when: 1590709946.06871
+when: 1590755775.74926
 asMultiple: FALSE
 asStatic: FALSE
-ignoredFiles: docs|website
+ignoredFiles: local_only/datatest|local_only/datatest.csv|local_only/graphtest.csv|local_only/graphtest2.csv|docs|website


### PR DESCRIPTION
Per #22, the shinyapps.io autodeploy makes changes, but often introduces bugs. 

So this pull request cancels future shinyapps.io autodeploy and also configures the deploy config file to ignore some unnecessary files. 